### PR TITLE
Create logs directory at startup for first time use

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -21,9 +21,6 @@ class FileManager:
 
     @staticmethod
     def migrate_files(file_paths: List[str]) -> int:
-        if not os.path.isdir(FileManager.get_storage_path('')):
-            os.mkdir(FileManager.get_storage_path(''))
-
         files_migrated: int = 0
         for path in file_paths:
             from_path: str = FileManager.get_executable_relative_path(path)
@@ -32,6 +29,9 @@ class FileManager:
                 files_migrated += 1
         return files_migrated
 
+
+if not os.path.isdir(FileManager.get_storage_path('')):
+    os.mkdir(FileManager.get_storage_path(''))
 
 logger: logging.Logger = logging.getLogger('Valorant-Zone-Stats')
 logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
When running the program for the first time, the program tries to use `logging.FileHandler` to create the `debug.log` file in the `Valorant-Zone-Stats` folder in `AppData`. The issue is that this folder does not exist when a new user starts the app for the first time. and `logging.FileHandler` will not create this directory on its own. 

Hence the program crashes with the following error

```
FileNotFoundError: [Errno 2] No such file or directory: 'C:\\Users\\<username>\\AppData\\Roaming\\Valorant-Zone-Stats\\debug.log'
```

I notice that `migrate_files` tries to create that directory if it does not exist, however it is after the logger is attempted to initialize, hence the required directories are never created. 

Instead of creating the app folder in `migrate_files` function which is run on module's main method. We can create that folder one time (if does not already exist), right before the logger is loaded, this will ensure that the folder is always present in all cases.

This PR should fix the above issue and has been tested on my machine.